### PR TITLE
fix migrations

### DIFF
--- a/database/migrations/2021_09_01_125947_create_account_table.php
+++ b/database/migrations/2021_09_01_125947_create_account_table.php
@@ -36,6 +36,6 @@ class CreateAccountTable extends Migration
      */
     public function down()
     {
-        Schema::downIfExists('account');
+        Schema::dropIfExists('account');
     }
 }

--- a/database/migrations/2021_10_01_164139_alter_table_order_item_add_fk.php
+++ b/database/migrations/2021_10_01_164139_alter_table_order_item_add_fk.php
@@ -25,8 +25,8 @@ class AlterTableOrderItemAddFk extends Migration
      */
     public function down()
     {
-        Schema::table('account', function (Blueprint $table) {
-            $table->dropForeign(['order_id']);
+        Schema::table('order_item', function (Blueprint $table) {
+            $table->dropForeign('order_item_order_id_foreign');
         });
     }
 }

--- a/database/migrations/2022_07_09_215706_alter_lead_table.php
+++ b/database/migrations/2022_07_09_215706_alter_lead_table.php
@@ -27,7 +27,7 @@ class AlterLeadTable extends Migration
      */
     public function down()
     {
-        Schema::table('customer', function (Blueprint $table) {
+        Schema::table('lead', function (Blueprint $table) {
             $table->dropColumn('website');
             $table->dropColumn('notes');
             $table->dropColumn('seller_id');

--- a/database/migrations/2022_09_20_103926_alter_table_user_primary2bigint.php
+++ b/database/migrations/2022_09_20_103926_alter_table_user_primary2bigint.php
@@ -27,7 +27,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table('user', function (Blueprint $table) {
-            $table->dropIndex('company_id');
+            $table->dropForeign('user_company_id_foreign');
         });
     }
 };


### PR DESCRIPTION
Fix migrations so that the `php artisan migrate:refresh --seed` command can be used.

The migrate:refresh command will roll back all of your migrations and then execute the migrate command. This command effectively re-creates your entire database.

Refresh the database and run all database seeds...
`php artisan migrate:refresh --seed`
