### PR TITLE
fix-typo-and-ternary-operator-super-admin

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -22,7 +22,7 @@ class Product extends Model
 
     public function company()
     {
-        return $this->hasOne(App\Models\Compony::class, 'id', 'company_id');
+        return $this->hasOne(Company::class, 'id', 'company_id');
     }
 
     public function category()

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,9 +28,7 @@ class AuthServiceProvider extends ServiceProvider
         //Custom
         // Implicitly grant "SuperAdmin" role all permission checks using can()
         Gate::before(function ($user, $ability) {
-            if ($user->hasRole('SuperAdmin')) {
-                return true;
-            }
+            return $user->hasRole('SuperAdmin') ? true : null;
         });
     }
 }


### PR DESCRIPTION
fix typo error: `App\Models\Compony::class` -> `Company::class` and fix unnecessary fully qualified name.

chage to  ternary operator: `$user->hasRole('SuperAdmin') ? true : null;`



