### PR TITLE
Implement Eager Loading in queries

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -123,7 +123,7 @@ class Customer extends Model
             }
         }
 
-        return $customers->paginate(10);
+        return $customers->with('seller', 'industry')->paginate(10);
     }
 
     public function getCountByCompany(int $company_id): int

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -125,7 +125,7 @@ class Lead extends Model
             }
         }
 
-        return $leads->paginate(10);
+        return $leads->with('seller', 'industry')->paginate(10);
     }
 
     public function getCountByCompany(int $company_id): int

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -171,6 +171,6 @@ final class Order extends Model
      */
     public function getAllActiveByCompany(int $company_id)
     {
-        return Order::where('company_id', $company_id)->paginate(10);
+        return Order::with('customer')->where('company_id', $company_id)->paginate(10);
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -42,7 +42,7 @@ class Product extends Model
 
     public function getAllByCompanyId($company_id)
     {
-        return Product::where('company_id', '=', $company_id)
+        return Product::with('category', 'brand')->where('company_id', '=', $company_id)
                         ->orderBy('name', 'asc')->get();
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -11,6 +11,11 @@ class Ticket extends Model
 
     protected $table = 'ticket';
 
+    public function customer()
+    {
+        return $this->hasOne(Customer::class, 'id', 'customer_id');
+    }
+
     public function createdBy()
     {
         return $this->hasOne(\App\Models\User::class, 'id', 'created_by');
@@ -18,6 +23,6 @@ class Ticket extends Model
 
     public function getLatestByCompany(int $company_id)
     {
-        return Ticket::where('company_id', $company_id)->orderBy('created_at', 'DESC')->get();
+        return Ticket::with('customer', 'createdBy')->where('company_id', $company_id)->orderBy('created_at', 'DESC')->get();
     }
 }


### PR DESCRIPTION
Eager loading alleviates the "N + 1" query problem.

When building a query, you may specify which relationships should be eager loaded using the `with` method.

Before.... **`[27 queries]`**
![image](https://user-images.githubusercontent.com/2836337/200084814-01d5412f-de13-47fa-b454-a94b44fa277f.png)

and after  **`[9 queries]`**
![image](https://user-images.githubusercontent.com/2836337/200084836-a238bb44-667f-4406-b6af-ebef7da886ec.png)


