### PR TITLE
Add pint config file to allow phpdoc separation

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -11,5 +11,5 @@ jobs:
             preset: laravel
             verboseMode: true
             testMode: true
-            configPath: "vendor/my-company/coding-style/pint.json"
+            configPath: "pint.json"
           

--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -4,5 +4,4 @@ namespace App\Http\Controllers\Api\Auth;
 
 class LoginController
 {
-
 }

--- a/app/Http/Controllers/Api/Doc/DocGeneratorController.php
+++ b/app/Http/Controllers/Api/Doc/DocGeneratorController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers\Api\Doc;
 
 use Illuminate\Http\JsonResponse;
-$api_host = (getenv() === "production") ? "roskus.com" : "localhost";
-define("API_HOST", $api_host);
+
+$api_host = (getenv() === 'production') ? 'roskus.com' : 'localhost';
+define('API_HOST', $api_host);
 
 /**
  * @OA\Info(

--- a/app/Http/Controllers/Api/Lead/LeadListController.php
+++ b/app/Http/Controllers/Api/Lead/LeadListController.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Http\Controllers\Api\Lead;
 
 use App\Models\Lead;

--- a/app/Http/Controllers/Api/Lead/LeadReadController.php
+++ b/app/Http/Controllers/Api/Lead/LeadReadController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api\Lead;
 
 use App\Models\Lead;
-use Illuminate\Http\Request;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 
 class LeadReadController
 {
@@ -30,15 +30,13 @@ class LeadReadController
     public function read(Request $request, int $id): \Illuminate\Http\JsonResponse
     {
         $lead = null;
-        try
-        {
+        try {
             $lead = Lead::findOrFail($id);
             $status = 200;
-        }
-        catch(ModelNotFoundException $e)
-        {
+        } catch(ModelNotFoundException $e) {
             $status = 404;
         }
+
         return response()->json(['lead' => $lead], $status);
     }
 }

--- a/app/Http/Controllers/Email/EmailCreateController.php
+++ b/app/Http/Controllers/Email/EmailCreateController.php
@@ -1,5 +1,7 @@
 <?php
-declare( strict_types = 1 );
+
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Email;
 
 use App\Http\Controllers\MainController;

--- a/app/Http/Controllers/Email/EmailDeleteController.php
+++ b/app/Http/Controllers/Email/EmailDeleteController.php
@@ -1,5 +1,7 @@
 <?php
-declare( strict_types = 1 );
+
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Email;
 
 use App\Http\Controllers\MainController;

--- a/app/Http/Controllers/Email/EmailSendController.php
+++ b/app/Http/Controllers/Email/EmailSendController.php
@@ -1,5 +1,7 @@
 <?php
-declare( strict_types = 1 );
+
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Email;
 
 use App\Http\Controllers\MainController;

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -1,5 +1,7 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -66,6 +68,7 @@ class Contact extends Model
     use HasFactory;
 
     protected $table = 'contact';
+
     protected $fillable = [
         'first_name',
         'last_name',

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,6 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "phpdoc_separation": false
+    } 
+}


### PR DESCRIPTION
Add pint config file to allow phpdoc separation.

This makes it so that errors are not shown in the comments of the api documentation with swagger