### PR TITLE
feat: add missing delete controllers for Supplier and BankAccount

### DIFF
--- a/app/Http/Controllers/Bank/Account/BankAccountDeleteController.php
+++ b/app/Http/Controllers/Bank/Account/BankAccountDeleteController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bank\Account;
+
+use App\Http\Controllers\MainController;
+use App\Models\Bank\Account as BankAccount;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class BankAccountDeleteController extends MainController
+{
+    public function delete(Request $request, int $id): RedirectResponse
+    {
+        $bankAccount = BankAccount::where('id', $id)
+            ->where('company_id', Auth::user()->company_id)
+            ->firstOrFail();
+
+        $bankAccount->delete();
+
+        return redirect('/bank-account');
+    }
+}

--- a/app/Http/Controllers/Supplier/SupplierDeleteController.php
+++ b/app/Http/Controllers/Supplier/SupplierDeleteController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Supplier;
+
+use App\Http\Controllers\MainController;
+use App\Models\Supplier;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SupplierDeleteController extends MainController
+{
+    public function delete(Request $request, int $id): RedirectResponse
+    {
+        $supplier = Supplier::where('id', $id)
+            ->where('company_id', Auth::user()->company_id)
+            ->firstOrFail();
+
+        $supplier->delete();
+
+        return redirect('/supplier');
+    }
+}

--- a/app/Models/Bank/Account.php
+++ b/app/Models/Bank/Account.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace App\Models\Bank;
 
 use App\Models\Bank;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Squire\Models\Country;
 
 class Account extends Model
 {
+    use HasFactory;
+
     protected $table = 'bank_account';
 
     protected $fillable = [
+        'company_id',
         'country_id',
         'bank_id',
         'currency',

--- a/database/factories/Bank/AccountFactory.php
+++ b/database/factories/Bank/AccountFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Bank;
+
+use App\Models\Bank;
+use App\Models\Bank\Account;
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\DB;
+use Squire\Models\Country;
+
+/**
+ * @extends Factory<Account>
+ */
+class AccountFactory extends Factory
+{
+    protected $model = Account::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'company_id' => Company::factory(),
+            'bank_id' => function () {
+                $bank = Bank::factory()->create();
+
+                return DB::table('bank')->where('uuid', $bank->getKey())->value('id');
+            },
+            'country_id' => Country::all()->random(),
+            'currency' => fake()->currencyCode(),
+            'iban' => fake()->iban(),
+            'amount' => fake()->randomFloat(3, 0, 100000),
+            'notes' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,7 @@
     <env name="BCRYPT_ROUNDS" value="4"/>
     <env name="CACHE_DRIVER" value="array"/>
     <env name="DB_CONNECTION" value="mysql"/>
+    <env name="DB_HOST" value="127.0.0.1"/>
     <env name="DB_DATABASE" value="pflow_crm_test"/>
     <env name="MAIL_MAILER" value="array"/>
     <env name="PULSE_ENABLED" value="false"/>

--- a/routes/module/bank_account.php
+++ b/routes/module/bank_account.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Bank\Account\BankAccountCreateController;
+use App\Http\Controllers\Bank\Account\BankAccountDeleteController;
 use App\Http\Controllers\Bank\Account\BankAccountIndexController;
 use App\Http\Controllers\Bank\Account\BankAccountSaveController;
 use App\Http\Controllers\Bank\Account\BankAccountUpdateController;
@@ -23,3 +24,7 @@ Route::get('/bank-account/update/{id}',
 Route::get('/bank-account/save',
     [BankAccountSaveController::class, 'save'])
     ->can('create bank');
+
+Route::get('/bank-account/delete/{id}',
+    [BankAccountDeleteController::class, 'delete'])
+    ->can('delete bank');

--- a/routes/module/supplier.php
+++ b/routes/module/supplier.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Supplier\Contact\ContactExportVCard;
 use App\Http\Controllers\Supplier\Contact\ContactSaveController;
 use App\Http\Controllers\Supplier\Contact\ContactUpdateController;
 use App\Http\Controllers\Supplier\SupplierCreateController;
+use App\Http\Controllers\Supplier\SupplierDeleteController;
 use App\Http\Controllers\Supplier\SupplierIndexController;
 use App\Http\Controllers\Supplier\SupplierSaveController;
 use App\Http\Controllers\Supplier\SupplierUpdateController;
@@ -17,6 +18,7 @@ Route::match(['get', 'post'], '/supplier', [SupplierIndexController::class, 'ind
 Route::get('/supplier/create', [SupplierCreateController::class, 'create']);
 Route::get('/supplier/update/{id}', [SupplierUpdateController::class, 'update']);
 Route::post('/supplier/save', [SupplierSaveController::class, 'save']);
+Route::get('/supplier/delete/{id}', [SupplierDeleteController::class, 'delete']);
 
 Route::post('/supplier/contact/save', [ContactSaveController::class, 'save']);
 Route::get('/supplier/contact/export-vcard/{id}', [ContactExportVCard::class, 'export']);

--- a/tests/Feature/Controllers/Bank/BankAccountDeleteControllerTest.php
+++ b/tests/Feature/Controllers/Bank/BankAccountDeleteControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Bank;
+
+use App\Models\Bank\Account as BankAccount;
+use App\Models\Company;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BankAccountDeleteControllerTest extends TestCase
+{
+    #[Test]
+    public function it_can_delete_bank_account(): void
+    {
+        $bankAccount = BankAccount::factory()->create(['company_id' => $this->user->company_id]);
+
+        $response = $this->get('/bank-account/delete/'.$bankAccount->id);
+
+        $response->assertRedirect('/bank-account');
+        $this->assertDatabaseMissing('bank_account', ['id' => $bankAccount->id]);
+    }
+
+    #[Test]
+    public function it_returns_404_when_bank_account_not_found(): void
+    {
+        $response = $this->get('/bank-account/delete/99999');
+
+        $response->assertNotFound();
+    }
+
+    #[Test]
+    public function it_cannot_delete_bank_account_from_another_company(): void
+    {
+        $otherCompany = Company::factory()->create();
+        $bankAccount = BankAccount::factory()->create(['company_id' => $otherCompany->id]);
+
+        $response = $this->get('/bank-account/delete/'.$bankAccount->id);
+
+        $response->assertNotFound();
+        $this->assertDatabaseHas('bank_account', ['id' => $bankAccount->id]);
+    }
+}

--- a/tests/Feature/Controllers/Supplier/SupplierDeleteControllerTest.php
+++ b/tests/Feature/Controllers/Supplier/SupplierDeleteControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Supplier;
+
+use App\Models\Company;
+use App\Models\Supplier;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SupplierDeleteControllerTest extends TestCase
+{
+    #[Test]
+    public function it_can_delete_supplier(): void
+    {
+        $supplier = Supplier::factory()->create(['company_id' => $this->user->company_id]);
+
+        $response = $this->get('/supplier/delete/'.$supplier->id);
+
+        $response->assertRedirect('/supplier');
+        $this->assertDatabaseMissing('supplier', ['id' => $supplier->id]);
+    }
+
+    #[Test]
+    public function it_returns_404_when_supplier_not_found(): void
+    {
+        $response = $this->get('/supplier/delete/99999');
+
+        $response->assertNotFound();
+    }
+
+    #[Test]
+    public function it_cannot_delete_supplier_from_another_company(): void
+    {
+        $otherCompany = Company::factory()->create();
+        $supplier = Supplier::factory()->create(['company_id' => $otherCompany->id]);
+
+        $response = $this->get('/supplier/delete/'.$supplier->id);
+
+        $response->assertNotFound();
+        $this->assertDatabaseHas('supplier', ['id' => $supplier->id]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -19,6 +20,8 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->app->make(PermissionRegistrar::class)->forgetCachedPermissions();
 
         $this->freezeTime();
 


### PR DESCRIPTION
- Add SupplierDeleteController with company-scoped delete (prevents cross-company deletion)
- Add BankAccountDeleteController with same company-scoped pattern
- Add routes GET /supplier/delete/{id} and GET /bank-account/delete/{id}
- Add Bank\AccountFactory (was missing, blocking BankAccount-related tests)
- Add company_id to BankAccount fillable and HasFactory trait (was missing)
- Fix phpunit.xml DB_HOST override (was pointing to Docker hostname crm-db, unreachable outside Docker)
- Fix TestCase: clear Spatie permission cache between tests to prevent cross-test pollution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete bank accounts with automatic redirect to the account list
  * Users can now delete suppliers with automatic redirect to the supplier list

* **Tests**
  * Added feature tests covering successful deletion, 404 error handling, and data validation for bank accounts
  * Added feature tests covering successful deletion, 404 error handling, and data validation for suppliers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Roskus/prospero-flow-crm/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->