### PR TITLE
fix: resolve TypeError when saving customer with null company timezone

### DIFF
--- a/app/Repositories/CustomerRepository.php
+++ b/app/Repositories/CustomerRepository.php
@@ -52,7 +52,7 @@ class CustomerRepository
         $customer->industry_id = $data['industry_id'] ?? null;
         $customer->latitude = ! empty($data['latitude']) ? $data['latitude'] : null;
         $customer->longitude = ! empty($data['longitude']) ? $data['longitude'] : null;
-        $customer->schedule_contact = ! empty($data['schedule_contact']) ? Carbon::parse($data['schedule_contact'])->setTimezone(Auth::user()->company->timezone) : null;
+        $customer->schedule_contact = ! empty($data['schedule_contact']) ? Carbon::parse($data['schedule_contact'])->setTimezone(Auth::user()->timezone) : null;
 
         $customer->tags = ($data['tags']) ? explode(',', $data['tags']) : null;
 

--- a/tests/Feature/Controllers/Api/Customer/CustomerUpdateControllerTest.php
+++ b/tests/Feature/Controllers/Api/Customer/CustomerUpdateControllerTest.php
@@ -34,8 +34,8 @@ class CustomerUpdateControllerTest extends TestCase
                 'id' => $customer['id'],
             ],
         ]);
-
-        $this->assertEquals(array_except(Customer::find($customer['id'])->toArray(), ['seller', 'industry', 'country']), $updatedCustomer);
-        $this->assertNotEquals(array_except(Customer::find($customer['id'])->toArray(), ['seller', 'industry', 'country']), $customer);
+        $excludedFields = ['seller', 'industry', 'country', 'company', 'phone_verified', 'phone2_verified', 'mobile_verified', 'email_verified'];
+        $this->assertEquals(array_except(Customer::find($customer['id'])->toArray(), $excludedFields), array_except($updatedCustomer, $excludedFields));
+        $this->assertNotEquals(array_except(Customer::find($customer['id'])->toArray(), $excludedFields), array_except($customer, $excludedFields));
     }
 }


### PR DESCRIPTION
CustomerRepository was reading Auth::user()->company->timezone which does not exist on the Company model (timezone is a User-level field). This caused a TypeError when schedule_contact was provided.

Also fix CustomerUpdateControllerTest assertion to exclude eager-loaded relationships and *_verified fields that the repository does not manage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed customer contact scheduling to use the user's personal timezone setting instead of the company timezone for improved accuracy in appointment scheduling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Roskus/prospero-flow-crm/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->