### PR TITLE
fix: address security vulnerabilities in permission, email attachment…

### DIFF
--- a/app/Http/Controllers/Api/Company/CompanyUpdateController.php
+++ b/app/Http/Controllers/Api/Company/CompanyUpdateController.php
@@ -7,15 +7,11 @@ namespace App\Http\Controllers\Api\Company;
 use App\Repositories\CompanyRepository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class CompanyUpdateController
 {
-    private CompanyRepository $companyRepository;
-
-    public function __construct(CompanyRepository $companyRepository)
-    {
-        $this->companyRepository = $companyRepository;
-    }
+    public function __construct(private CompanyRepository $companyRepository) {}
 
     /**
      * @OA\Put(
@@ -41,14 +37,13 @@ class CompanyUpdateController
      */
     public function update(Request $request, int $id): JsonResponse
     {
-        $status = 400;
-        $params['id'] = $id;
-        $params = array_merge($params, $request->all());
-        $company = $this->companyRepository->save($params);
-        if ($company) {
-            $status = 200;
+        if (Auth::user()->company_id !== $id) {
+            return response()->json(['message' => 'Unauthorized'], 403);
         }
 
-        return response()->json($company, $status);
+        $params = array_merge(['id' => $id], $request->all());
+        $company = $this->companyRepository->save($params);
+
+        return response()->json($company, $company ? 200 : 400);
     }
 }

--- a/app/Http/Controllers/Email/EmailDownloadAttachmentController.php
+++ b/app/Http/Controllers/Email/EmailDownloadAttachmentController.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Email;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\MainController;
 use App\Models\Email\Attach;
+use Illuminate\Support\Facades\Auth;
 
-class EmailDownloadAttachmentController extends Controller
+class EmailDownloadAttachmentController extends MainController
 {
     public function downloadAttachment(int $attachmentId)
     {
-        $attach = Attach::findOrFail($attachmentId);
+        $attach = Attach::with('email')->findOrFail($attachmentId);
+
+        abort_if($attach->email->company_id !== Auth::user()->company_id, 403);
+
         $filePath = storage_path('app/'.$attach->file);
 
         return response()->download($filePath, $attach->original_name);

--- a/app/Http/Controllers/Permission/PermissionIndexController.php
+++ b/app/Http/Controllers/Permission/PermissionIndexController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Permission;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\MainController;
+use Illuminate\Http\Request;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
-class PermissionIndexController extends Controller
+class PermissionIndexController extends MainController
 {
-    public function index()
+    public function index(Request $request)
     {
         $roles = Role::with('permissions')->get();
         $permissions = Permission::all();

--- a/app/Http/Controllers/Permission/PermissionSaveController.php
+++ b/app/Http/Controllers/Permission/PermissionSaveController.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Permission;
 
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\MainController;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Spatie\Permission\Models\Role;
 
-class PermissionSaveController extends Controller
+class PermissionSaveController extends MainController
 {
     public function save(Request $request): RedirectResponse
     {

--- a/app/Models/Email/Attach.php
+++ b/app/Models/Email/Attach.php
@@ -4,9 +4,18 @@ declare(strict_types=1);
 
 namespace App\Models\Email;
 
+use App\Models\Email;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Attach extends Model
 {
     protected $table = 'email_attach';
+
+    protected $guarded = [];
+
+    public function email(): BelongsTo
+    {
+        return $this->belongsTo(Email::class);
+    }
 }

--- a/tests/Feature/Controllers/Api/Company/CompanyUpdateControllerTest.php
+++ b/tests/Feature/Controllers/Api/Company/CompanyUpdateControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Company;
+
+use App\Models\Company;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CompanyUpdateControllerTest extends TestCase
+{
+    #[Test]
+    public function it_blocks_cross_tenant_company_update(): void
+    {
+        $otherCompany = Company::factory()->create();
+
+        $response = $this->actingAs($this->user, 'api')
+            ->putJson("/api/company/{$otherCompany->id}", [
+                'name' => 'PWNED',
+                'country_id' => 'us',
+            ]);
+
+        $response->assertForbidden();
+        $this->assertNotEquals('PWNED', $otherCompany->fresh()->name);
+    }
+
+    #[Test]
+    public function it_allows_updating_own_company(): void
+    {
+        $company = $this->user->company;
+
+        $response = $this->actingAs($this->user, 'api')
+            ->putJson("/api/company/{$company->id}", [
+                'name' => 'Updated Name',
+                'country_id' => $company->country_id,
+                'currency' => $company->currency,
+            ]);
+
+        $response->assertOk();
+        $this->assertEquals('Updated Name', $company->fresh()->name);
+    }
+}

--- a/tests/Feature/Controllers/Email/EmailDownloadAttachmentControllerTest.php
+++ b/tests/Feature/Controllers/Email/EmailDownloadAttachmentControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Email;
+
+use App\Models\Email;
+use App\Models\Email\Attach;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EmailDownloadAttachmentControllerTest extends TestCase
+{
+    #[Test]
+    public function it_blocks_unauthenticated_attachment_download(): void
+    {
+        $email = Email::factory()->create(['company_id' => $this->user->company_id]);
+        $attach = Attach::create([
+            'email_id' => $email->id,
+            'original_name' => 'test.txt',
+            'file' => 'company/test/email/1/test.txt',
+            'mime' => 'text/plain',
+        ]);
+
+        auth()->guard('web')->logout();
+
+        $response = $this->get("/email/download-attachment/{$attach->id}");
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_blocks_cross_tenant_attachment_download(): void
+    {
+        $otherUser = User::factory()->create();
+        $email = Email::factory()->create(['company_id' => $otherUser->company_id]);
+        $attach = Attach::create([
+            'email_id' => $email->id,
+            'original_name' => 'secret.txt',
+            'file' => 'company/other/email/1/secret.txt',
+            'mime' => 'text/plain',
+        ]);
+
+        $response = $this->get("/email/download-attachment/{$attach->id}");
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function it_allows_own_tenant_attachment_download(): void
+    {
+        $filePath = storage_path('app/company/test/email/1/file.txt');
+        @mkdir(dirname($filePath), 0755, true);
+        file_put_contents($filePath, 'content');
+
+        $email = Email::factory()->create(['company_id' => $this->user->company_id]);
+        $attach = Attach::create([
+            'email_id' => $email->id,
+            'original_name' => 'file.txt',
+            'file' => 'company/test/email/1/file.txt',
+            'mime' => 'text/plain',
+        ]);
+
+        $response = $this->get("/email/download-attachment/{$attach->id}");
+
+        @unlink($filePath);
+
+        $response->assertOk();
+        $response->assertDownload('file.txt');
+    }
+}

--- a/tests/Feature/Controllers/Permission/PermissionSaveControllerTest.php
+++ b/tests/Feature/Controllers/Permission/PermissionSaveControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Permission;
+
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PermissionSaveControllerTest extends TestCase
+{
+    #[Test]
+    public function it_requires_authentication_to_view_permissions(): void
+    {
+        $response = $this->get('/permission');
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function it_blocks_unauthenticated_access_to_view_permissions(): void
+    {
+        $this->post('/logout');
+
+        $response = $this->get('/permission');
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_blocks_unauthenticated_permission_save(): void
+    {
+        $this->post('/logout');
+
+        $response = $this->post('/permission', []);
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_can_save_permissions(): void
+    {
+        $role = Role::create(['name' => 'Buyer', 'guard_name' => 'web']);
+        $permission = Permission::create(['name' => 'edit articles', 'guard_name' => 'web']);
+
+        $response = $this->post('/permission', [
+            'roles' => [$role->id => [$permission->id => 1]],
+        ]);
+
+        $response->assertRedirect('/permission');
+        $this->assertTrue($role->fresh()->hasPermissionTo('edit articles'));
+    }
+}


### PR DESCRIPTION
…, and company API endpoints

- PermissionIndexController and PermissionSaveController now extend MainController requiring authentication and locked-session middleware
- EmailDownloadAttachmentController now extends MainController and verifies that the requested attachment belongs to the authenticated user's company
- CompanyUpdateController (API) now verifies tenant ownership before allowing updates
- Add email() relationship and $guarded to Attach model
- Add tests covering unauthenticated access and cross-tenant isolation

Fixes: unauthenticated permission rewrite, unauthenticated email attachment download, and cross-tenant company profile modification (GHSA-rx76-rw4p-84j7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added authorization checks to prevent users from updating companies they don't own.
  * Added authorization checks to prevent users from downloading email attachments from other companies.

* **Tests**
  * Added test coverage for company update authorization and cross-tenant scenarios.
  * Added test coverage for email attachment download authorization and cross-tenant access prevention.
  * Added test coverage for permission management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Roskus/prospero-flow-crm/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->