### PR TITLE
fix: validate company ownership of foreign keys on transaction save

### DIFF
--- a/app/Http/Controllers/Transaction/TransactionSaveController.php
+++ b/app/Http/Controllers/Transaction/TransactionSaveController.php
@@ -6,7 +6,12 @@ namespace App\Http\Controllers\Transaction;
 
 use App\Http\Controllers\MainController;
 use App\Http\Requests\TransactionSaveRequest;
+use App\Models\Bank\Account as BankAccount;
+use App\Models\BankCard;
+use App\Models\Customer;
+use App\Models\Supplier;
 use App\Models\Transaction;
+use App\Models\Transaction\Category as TransactionCategory;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
@@ -18,8 +23,33 @@ class TransactionSaveController extends MainController
             ? new Transaction
             : Transaction::where('company_id', Auth::user()->company_id)->findOrFail($request->id);
 
-        $transaction->company_id = Auth::user()->company_id;
-        $transaction->fill($request->validated());
+        $companyId = Auth::user()->company_id;
+
+        $transaction->company_id = $companyId;
+
+        $validated = $request->validated();
+
+        if (! empty($validated['transaction_category_id'])) {
+            TransactionCategory::where('company_id', $companyId)->findOrFail($validated['transaction_category_id']);
+        }
+
+        if (! empty($validated['bank_account_id'])) {
+            BankAccount::where('company_id', $companyId)->findOrFail($validated['bank_account_id']);
+        }
+
+        if (! empty($validated['bank_card_id'])) {
+            BankCard::where('company_id', $companyId)->findOrFail($validated['bank_card_id']);
+        }
+
+        if (! empty($validated['customer_id'])) {
+            Customer::where('company_id', $companyId)->findOrFail($validated['customer_id']);
+        }
+
+        if (! empty($validated['supplier_id'])) {
+            Supplier::where('company_id', $companyId)->findOrFail($validated['supplier_id']);
+        }
+
+        $transaction->fill($validated);
 
         if ($request->hasFile('attachment')) {
             if ($transaction->attachment) {

--- a/app/Http/Requests/TransactionSaveRequest.php
+++ b/app/Http/Requests/TransactionSaveRequest.php
@@ -57,23 +57,31 @@ class TransactionSaveRequest extends FormRequest
             'bank_account_id' => [
                 'nullable',
                 'integer',
-                Rule::exists('bank_account', 'id')->where('company_id', $this->user()?->company_id),
+                Rule::exists('bank_account', 'id')
+                    ->where('company_id', $this->user()?->company_id)
+                    ->whereNull('bank_account.deleted_at'),
             ],
             'bank_card_id' => [
                 'nullable',
                 'integer',
-                Rule::exists('bank_card', 'id')->where('company_id', $this->user()?->company_id),
+                Rule::exists('bank_card', 'id')
+                    ->where('company_id', $this->user()?->company_id)
+                    ->whereNull('bank_card.deleted_at'),
             ],
             'reference' => ['nullable', 'string', 'max:80'],
             'customer_id' => [
                 'nullable',
                 'integer',
-                Rule::exists('customer', 'id')->where('company_id', $this->user()?->company_id),
+                Rule::exists('customer', 'id')
+                    ->where('company_id', $this->user()?->company_id)
+                    ->whereNull('customer.deleted_at'),
             ],
             'supplier_id' => [
                 'nullable',
                 'integer',
-                Rule::exists('supplier', 'id')->where('company_id', $this->user()?->company_id),
+                Rule::exists('supplier', 'id')
+                    ->where('company_id', $this->user()?->company_id)
+                    ->whereNull('supplier.deleted_at'),
             ],
             'notes' => ['nullable', 'string'],
             'attachment' => ['nullable', 'file', 'max:10240', 'mimes:pdf,jpg,jpeg,png,webp,doc,docx,xls,xlsx'],

--- a/app/Http/Requests/TransactionSaveRequest.php
+++ b/app/Http/Requests/TransactionSaveRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests;
 use App\Http\Requests\Concerns\SanitizesInput;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class TransactionSaveRequest extends FormRequest
 {
@@ -48,12 +49,32 @@ class TransactionSaveRequest extends FormRequest
             'due_date' => ['nullable', 'date'],
             'payment_date' => ['nullable', 'date'],
             'status' => ['required', 'in:pending,paid,overdue'],
-            'transaction_category_id' => ['nullable', 'integer'],
-            'bank_account_id' => ['nullable', 'integer'],
-            'bank_card_id' => ['nullable', 'integer'],
+            'transaction_category_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('transaction_category', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'bank_account_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('bank_account', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'bank_card_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('bank_card', 'id')->where('company_id', $this->user()?->company_id),
+            ],
             'reference' => ['nullable', 'string', 'max:80'],
-            'customer_id' => ['nullable', 'integer'],
-            'supplier_id' => ['nullable', 'integer'],
+            'customer_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('customer', 'id')->where('company_id', $this->user()?->company_id),
+            ],
+            'supplier_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('supplier', 'id')->where('company_id', $this->user()?->company_id),
+            ],
             'notes' => ['nullable', 'string'],
             'attachment' => ['nullable', 'file', 'max:10240', 'mimes:pdf,jpg,jpeg,png,webp,doc,docx,xls,xlsx'],
         ];

--- a/tests/Feature/Controllers/Transaction/TransactionSaveControllerTest.php
+++ b/tests/Feature/Controllers/Transaction/TransactionSaveControllerTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Controllers\Transaction;
 
+use App\Models\Bank\Account as BankAccount;
+use App\Models\BankCard;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Supplier;
 use App\Models\Transaction;
 use App\Models\User;
 use PHPUnit\Framework\Attributes\Test;
@@ -158,5 +163,191 @@ class TransactionSaveControllerTest extends TestCase
 
         $response->assertRedirect('/accounting');
         $this->assertDatabaseHas('transaction', ['name' => 'Allowed create']);
+    }
+
+    #[Test]
+    public function it_accepts_bank_account_belonging_to_own_company(): void
+    {
+        $bankAccount = BankAccount::factory()->create([
+            'company_id' => $this->user->company_id,
+        ]);
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Own bank account test',
+            'type' => 'expense',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'bank_account_id' => $bankAccount->id,
+        ]);
+
+        $response->assertRedirect('/accounting');
+        $this->assertDatabaseHas('transaction', ['name' => 'Own bank account test']);
+    }
+
+    #[Test]
+    public function it_rejects_bank_account_belonging_to_other_company(): void
+    {
+        $otherCompany = Company::factory()->create();
+        $bankAccount = BankAccount::factory()->create([
+            'company_id' => $otherCompany->id,
+        ]);
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Other company bank account test',
+            'type' => 'expense',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'bank_account_id' => $bankAccount->id,
+        ]);
+
+        $response->assertSessionHasErrors('bank_account_id');
+        $this->assertDatabaseMissing('transaction', ['name' => 'Other company bank account test']);
+    }
+
+    #[Test]
+    public function it_accepts_bank_card_belonging_to_own_company(): void
+    {
+        $bankAccount = BankAccount::factory()->create([
+            'company_id' => $this->user->company_id,
+        ]);
+
+        $bankCard = new BankCard;
+        $bankCard->company_id = $this->user->company_id;
+        $bankCard->bank_account_id = $bankAccount->id;
+        $bankCard->type = 'credit';
+        $bankCard->network = 'visa';
+        $bankCard->cardholder_name = 'Test Card';
+        $bankCard->number = '4111111111111111';
+        $bankCard->expires_month = 12;
+        $bankCard->expires_year = 2030;
+        $bankCard->save();
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Own bank card test',
+            'type' => 'expense',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'bank_card_id' => $bankCard->id,
+        ]);
+
+        $response->assertRedirect('/accounting');
+        $this->assertDatabaseHas('transaction', ['name' => 'Own bank card test']);
+    }
+
+    #[Test]
+    public function it_rejects_bank_card_belonging_to_other_company(): void
+    {
+        $otherCompany = Company::factory()->create();
+        $otherBankAccount = BankAccount::factory()->create([
+            'company_id' => $otherCompany->id,
+        ]);
+
+        $bankCard = new BankCard;
+        $bankCard->company_id = $otherCompany->id;
+        $bankCard->bank_account_id = $otherBankAccount->id;
+        $bankCard->type = 'credit';
+        $bankCard->network = 'visa';
+        $bankCard->cardholder_name = 'Other Company Card';
+        $bankCard->number = '4111111111111111';
+        $bankCard->expires_month = 12;
+        $bankCard->expires_year = 2030;
+        $bankCard->save();
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Other company bank card test',
+            'type' => 'expense',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'bank_card_id' => $bankCard->id,
+        ]);
+
+        $response->assertSessionHasErrors('bank_card_id');
+        $this->assertDatabaseMissing('transaction', ['name' => 'Other company bank card test']);
+    }
+
+    #[Test]
+    public function it_accepts_customer_belonging_to_own_company(): void
+    {
+        $customer = Customer::factory()->create([
+            'company_id' => $this->user->company_id,
+        ]);
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Own customer test',
+            'type' => 'income',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'customer_id' => $customer->id,
+        ]);
+
+        $response->assertRedirect('/accounting');
+        $this->assertDatabaseHas('transaction', ['name' => 'Own customer test']);
+    }
+
+    #[Test]
+    public function it_rejects_customer_belonging_to_other_company(): void
+    {
+        $otherCompany = Company::factory()->create();
+        $customer = Customer::factory()->create([
+            'company_id' => $otherCompany->id,
+        ]);
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Other company customer test',
+            'type' => 'income',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'customer_id' => $customer->id,
+        ]);
+
+        $response->assertSessionHasErrors('customer_id');
+        $this->assertDatabaseMissing('transaction', ['name' => 'Other company customer test']);
+    }
+
+    #[Test]
+    public function it_accepts_supplier_belonging_to_own_company(): void
+    {
+        $supplier = Supplier::factory()->create([
+            'company_id' => $this->user->company_id,
+        ]);
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Own supplier test',
+            'type' => 'expense',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'supplier_id' => $supplier->id,
+        ]);
+
+        $response->assertRedirect('/accounting');
+        $this->assertDatabaseHas('transaction', ['name' => 'Own supplier test']);
+    }
+
+    #[Test]
+    public function it_rejects_supplier_belonging_to_other_company(): void
+    {
+        $otherCompany = Company::factory()->create();
+        $supplier = Supplier::factory()->create([
+            'company_id' => $otherCompany->id,
+        ]);
+
+        $response = $this->post('/transaction/save', [
+            'name' => 'Other company supplier test',
+            'type' => 'expense',
+            'amount' => 100,
+            'issue_date' => '2025-06-19',
+            'status' => 'paid',
+            'supplier_id' => $supplier->id,
+        ]);
+
+        $response->assertSessionHasErrors('supplier_id');
+        $this->assertDatabaseMissing('transaction', ['name' => 'Other company supplier test']);
     }
 }

--- a/tests/Feature/Controllers/Transaction/TransactionSaveControllerTest.php
+++ b/tests/Feature/Controllers/Transaction/TransactionSaveControllerTest.php
@@ -182,7 +182,10 @@ class TransactionSaveControllerTest extends TestCase
         ]);
 
         $response->assertRedirect('/accounting');
-        $this->assertDatabaseHas('transaction', ['name' => 'Own bank account test']);
+        $this->assertDatabaseHas('transaction', [
+            'name' => 'Own bank account test',
+            'bank_account_id' => $bankAccount->id,
+        ]);
     }
 
     #[Test]
@@ -234,7 +237,10 @@ class TransactionSaveControllerTest extends TestCase
         ]);
 
         $response->assertRedirect('/accounting');
-        $this->assertDatabaseHas('transaction', ['name' => 'Own bank card test']);
+        $this->assertDatabaseHas('transaction', [
+            'name' => 'Own bank card test',
+            'bank_card_id' => $bankCard->id,
+        ]);
     }
 
     #[Test]
@@ -286,7 +292,10 @@ class TransactionSaveControllerTest extends TestCase
         ]);
 
         $response->assertRedirect('/accounting');
-        $this->assertDatabaseHas('transaction', ['name' => 'Own customer test']);
+        $this->assertDatabaseHas('transaction', [
+            'name' => 'Own customer test',
+            'customer_id' => $customer->id,
+        ]);
     }
 
     #[Test]
@@ -327,7 +336,10 @@ class TransactionSaveControllerTest extends TestCase
         ]);
 
         $response->assertRedirect('/accounting');
-        $this->assertDatabaseHas('transaction', ['name' => 'Own supplier test']);
+        $this->assertDatabaseHas('transaction', [
+            'name' => 'Own supplier test',
+            'supplier_id' => $supplier->id,
+        ]);
     }
 
     #[Test]

--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-const APP_VERSION = '5.14.0';
+const APP_VERSION = '5.14.1';

--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-const APP_VERSION = '5.14.1';
+const APP_VERSION = '5.14.2';


### PR DESCRIPTION
Thanks to d1se0 for reporting this CWE-639 vulnerability and to dario.rivas for validating the finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction validation to ensure linked categories, accounts, cards, customers, and suppliers belong to the current company.
  * Prevented transactions from being saved with records belonging to another company.

* **Tests**
  * Added coverage for valid and invalid cross-company transaction references.

* **Chores**
  * Updated the application version to 5.14.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->