### PR TITLE
fix(security): add CSRF protection to order confirmation endpoint

### DIFF
--- a/resources/views/order/index.blade.php
+++ b/resources/views/order/index.blade.php
@@ -52,10 +52,12 @@
                         <i class="las la-pen"></i>
                     </a>
 
-                    <a href="{{ url('/order/confirm/'.$order->order_number) }}" title="{{ __('Confirm') }}"
-                       class="btn btn-xs btn-success text-white">
-                        <i class="las la-check-circle"></i>
-                    </a>
+                    <form method="POST" action="{{ route('order.confirm', $order->order_number) }}" style="display:inline;">
+                        @csrf
+                        <button type="submit" title="{{ __('Confirm') }}" class="btn btn-xs btn-success text-white" onclick="return confirm('{{ __('Are you sure you want to confirm the order: :id?', ['id' => $order->order_number]) }}')">
+                            <i class="las la-check-circle"></i>
+                        </button>
+                    </form>
                     @endif
 
                     <a href="{{ url('/order/download/'.$order->order_number) }}" title="{{ __('Download') }}"

--- a/routes/module/order.php
+++ b/routes/module/order.php
@@ -20,4 +20,6 @@ Route::get('/order/delete/{order_number}', [OrderDeleteController::class, 'delet
 Route::post('/order/save', [OrderSaveController::class, 'save'])->can('create order')->can('update order');
 Route::get('/order/download/{order_number}', [OrderPdfController::class, 'download'])
     ->name('order-download')->can('read order');
-Route::get('/order/confirm/{order_number}', [OrderConfirmController::class, 'confirm'])->can('update order');
+Route::post('/order/confirm/{order_number}', [OrderConfirmController::class, 'confirm'])
+    ->name('order.confirm')
+    ->can('update order');

--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-const APP_VERSION = '5.15.10';
+const APP_VERSION = '5.15.11';


### PR DESCRIPTION
Changed the order confirmation endpoint from GET to POST to prevent CSRF attacks. GET requests bypass Laravel's CSRF middleware (VerifyCsrfToken only protects POST, PUT, PATCH, DELETE methods). The vulnerability allowed attackers to confirm orders without authorization via crafted links or embedded images.

Changes:
- Route::get → Route::post with route name for easy reference
- Updated view to use form submission with @csrf token
- Added confirmation dialog before form submission

All 17 order-related tests pass.

Thanks to DChacon, maalfer, and secur0 for reporting this vulnerability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured address handling for consistent display and storage of address details.
  * Added Spanish translations for scheduling, payroll, and calendar terminology.
* **Bug Fixes**
  * Order confirmation now uses a protected submission flow with CSRF validation and confirmation prompts.
* **UI Improvements**
  * Improved schedule readability with striped tables and color-coded work/break labels.
  * Clarified the time-entry menu label.
* **Documentation**
  * Added comprehensive contract-management specifications covering lifecycle, finances, relationships, renewals, signing, and authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->