### PR TITLE
fix(order): handle orders with null order_number and backfill missing…

### DIFF
--- a/app/Observers/OrderObserver.php
+++ b/app/Observers/OrderObserver.php
@@ -13,11 +13,13 @@ class OrderObserver
     public function creating(Order $order): void
     {
         DB::transaction(function () use ($order): void {
-            Company::where('id', $order->getCompanyId())
+            Company::withTrashed()
+                ->where('id', $order->getCompanyId())
                 ->lockForUpdate()
                 ->increment('last_order_number');
 
-            $order->order_number = Company::where('id', $order->getCompanyId())
+            $order->order_number = Company::withTrashed()
+                ->where('id', $order->getCompanyId())
                 ->value('last_order_number');
         });
     }

--- a/database/migrations/2026_08_16_173916_backfill_order_number_for_null_orders.php
+++ b/database/migrations/2026_08_16_173916_backfill_order_number_for_null_orders.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Assign sequential order numbers to orders that have a null order_number,
+     * keeping them unique per company, and sync the referenced order items and
+     * the company's last_order_number counter.
+     */
+    public function up(): void
+    {
+        $companyIds = DB::table('order')
+            ->whereNull('order_number')
+            ->distinct()
+            ->pluck('company_id');
+
+        foreach ($companyIds as $companyId) {
+            DB::transaction(function () use ($companyId): void {
+                $counter = (int) DB::table('company')
+                    ->where('id', $companyId)
+                    ->lockForUpdate()
+                    ->value('last_order_number');
+
+                $storedMax = (int) DB::table('order')
+                    ->where('company_id', $companyId)
+                    ->whereNotNull('order_number')
+                    ->max('order_number');
+
+                $next = max($counter, $storedMax);
+
+                $orderIds = DB::table('order')
+                    ->where('company_id', $companyId)
+                    ->whereNull('order_number')
+                    ->orderBy('id')
+                    ->pluck('id');
+
+                foreach ($orderIds as $orderId) {
+                    $next++;
+
+                    while (DB::table('order')
+                        ->where('company_id', $companyId)
+                        ->where('order_number', $next)
+                        ->exists()) {
+                        $next++;
+                    }
+
+                    DB::table('order')->where('id', $orderId)->update(['order_number' => $next]);
+
+                    DB::table('order_item')->where('order_id', $orderId)->update(['order_number' => $next]);
+                }
+
+                DB::table('company')
+                    ->where('id', $companyId)
+                    ->where('last_order_number', '<', $next)
+                    ->update(['last_order_number' => $next]);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // Intentionally a no-op: order numbers cannot be reliably un-assigned.
+    }
+};

--- a/resources/views/order/index.blade.php
+++ b/resources/views/order/index.blade.php
@@ -28,7 +28,11 @@
             @foreach($orders as $order)
             <tr>
                 <td>
+                    @if(!empty($order->order_number))
                     <a href="{{ url('order/show/'.$order->order_number) }}">{{ $order->orderNumber() }}</a>
+                    @else
+                    <span class="text-muted">—</span>
+                    @endif
                 </td>
                 <td>{{ (!empty($order->customer)) ? $order->customer->name : '' }}</td>
                 <td class="text-center">
@@ -41,6 +45,7 @@
                 <td>{{ $order->updated_at->format('d/m/Y H:i') }}</td>
                 <td><span class="badge bg-{{ $order->getStatusBadgeClass() }}">{{ __($order->getStatusLabel()) }}</span></td>
                 <td class="text-nowrap">
+                    @if(!empty($order->order_number))
                     <a href="{{ url('order/show/'.$order->order_number) }}" title="{{ __('View') }}"
                        class="btn btn-xs btn-primary text-white">
                         <i class="las la-eye"></i>
@@ -71,6 +76,9 @@
                         <i class="las la-trash-alt"></i>
                     </a>
                     @endcan
+                    @else
+                    <span class="text-muted">—</span>
+                    @endif
                 </td>
             </tr>
             @endforeach

--- a/tests/Feature/Controllers/Order/OrderIndexControllerTest.php
+++ b/tests/Feature/Controllers/Order/OrderIndexControllerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Order;
+
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Order;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class OrderIndexControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_order_index_when_an_order_has_a_null_order_number(): void
+    {
+        $this->createOrderWithoutNumber();
+
+        $response = $this->get('/order');
+
+        $response->assertOk();
+        $response->assertSee('Orders');
+        $response->assertSee('<span class="text-muted">—</span>', false);
+    }
+
+    #[Test]
+    public function it_renders_action_buttons_for_orders_with_an_order_number(): void
+    {
+        $order = Order::factory()->create([
+            'company_id' => $this->user->company_id,
+            'status' => Order::PENDING,
+        ]);
+
+        $response = $this->get('/order');
+
+        $response->assertOk();
+        $response->assertSee(route('order.confirm', $order->order_number));
+    }
+
+    #[Test]
+    public function it_does_not_render_a_confirm_form_for_orders_without_an_order_number(): void
+    {
+        $this->createOrderWithoutNumber();
+
+        $response = $this->get('/order');
+
+        $response->assertOk();
+        $response->assertDontSee('order/confirm/');
+        $response->assertDontSee('order/show/');
+    }
+
+    #[Test]
+    public function the_backfill_migration_assigns_sequential_order_numbers_per_company(): void
+    {
+        $companyA = Company::factory()->create();
+        $companyB = Company::factory()->create();
+
+        $existingA = $this->insertOrderRaw($companyA->id, ['order_number' => 5]);
+        $nullA1 = $this->insertOrderRaw($companyA->id, ['order_number' => null]);
+        $nullA2 = $this->insertOrderRaw($companyA->id, ['order_number' => null]);
+        $nullB = $this->insertOrderRaw($companyB->id, ['order_number' => null]);
+
+        $this->runBackfillMigration();
+
+        $this->assertSame(5, (int) DB::table('order')->where('id', $existingA)->value('order_number'));
+        $this->assertSame(6, (int) DB::table('order')->where('id', $nullA1)->value('order_number'));
+        $this->assertSame(7, (int) DB::table('order')->where('id', $nullA2)->value('order_number'));
+        $this->assertSame(1, (int) DB::table('order')->where('id', $nullB)->value('order_number'));
+    }
+
+    #[Test]
+    public function the_backfill_migration_continues_from_last_order_number_when_it_exceeds_stored_max(): void
+    {
+        $company = Company::factory()->create();
+        DB::table('company')->where('id', $company->id)->update(['last_order_number' => 10]);
+
+        $nullOrder = $this->insertOrderRaw($company->id, ['order_number' => null]);
+
+        $this->runBackfillMigration();
+
+        $this->assertSame(11, (int) DB::table('order')->where('id', $nullOrder)->value('order_number'));
+        $this->assertSame(11, (int) DB::table('company')->where('id', $company->id)->value('last_order_number'));
+    }
+
+    #[Test]
+    public function the_backfill_migration_syncs_order_items_and_company_counter(): void
+    {
+        $company = Company::factory()->create();
+        $product = Product::factory()->create();
+
+        $orderId = $this->insertOrderRaw($company->id, ['order_number' => null]);
+
+        DB::table('order_item')->insert([
+            'order_id' => $orderId,
+            'order_number' => null,
+            'product_id' => $product->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->runBackfillMigration();
+
+        $orderNumber = (int) DB::table('order')->where('id', $orderId)->value('order_number');
+
+        $this->assertSame($orderNumber, (int) DB::table('order_item')->where('order_id', $orderId)->value('order_number'));
+        $this->assertSame($orderNumber, (int) DB::table('company')->where('id', $company->id)->value('last_order_number'));
+    }
+
+    #[Test]
+    public function the_order_observer_assigns_a_sequential_order_number_on_create(): void
+    {
+        $company = Company::factory()->create();
+        $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+        $order = Order::create([
+            'company_id' => $company->id,
+            'customer_id' => $customer->id,
+            'status' => Order::PENDING,
+        ]);
+
+        $this->assertSame(1, (int) $order->order_number);
+        $this->assertSame(1, (int) $company->fresh()->last_order_number);
+    }
+
+    #[Test]
+    public function the_order_observer_assigns_a_number_when_the_company_is_soft_deleted(): void
+    {
+        $company = Company::factory()->create();
+        $company->delete();
+
+        $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+        $order = Order::create([
+            'company_id' => $company->id,
+            'customer_id' => $customer->id,
+            'status' => Order::PENDING,
+        ]);
+
+        $this->assertSame(1, (int) $order->order_number);
+        $this->assertSame(1, (int) Company::withTrashed()->where('id', $company->id)->value('last_order_number'));
+    }
+
+    private function createOrderWithoutNumber(): Order
+    {
+        $customer = Customer::factory()->create(['company_id' => $this->user->company_id]);
+
+        return Order::withoutEvents(function () use ($customer) {
+            $order = new Order;
+            $order->company_id = $this->user->company_id;
+            $order->customer_id = $customer->id;
+            $order->status = Order::PENDING;
+            $order->save();
+
+            return $order;
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function insertOrderRaw(int $companyId, array $overrides = []): int
+    {
+        $customer = Customer::factory()->create(['company_id' => $companyId]);
+
+        return DB::table('order')->insertGetId(array_merge([
+            'company_id' => $companyId,
+            'customer_id' => $customer->id,
+            'status' => Order::PENDING,
+            'amount' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], $overrides));
+    }
+
+    private function runBackfillMigration(): void
+    {
+        $migration = require database_path('migrations/2026_08_16_173916_backfill_order_number_for_null_orders.php');
+        $migration->up();
+    }
+}

--- a/version.php
+++ b/version.php
@@ -1,3 +1,3 @@
 <?php
 
-const APP_VERSION = '5.16.0';
+const APP_VERSION = '5.16.1';


### PR DESCRIPTION
… numbers

Fix a production 500 on the orders list when an order has a null order_number (e.g. created before the order-number feature or when its company was soft-deleted).

- Backfill migration assigns sequential, per-company order numbers to null orders and syncs order_item.order_number and company.last_order_number.
- OrderObserver now uses withTrashed() so soft-deleted companies do not leave order_number null on new orders.
- Order index view guards the action buttons so a null order_number no longer crashes rendering (route('order.confirm')).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Assigned sequential, company-specific order numbers to previously unnumbered orders.
  - Preserved numbering continuity and synchronized related order details.
  - Enabled order numbering for archived companies.
  - Displayed an em dash and hid unavailable actions when an order number is missing.

- **Release**
  - Updated the application version to 5.16.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->